### PR TITLE
feat(zeroclaw): bump to 0.7.5 with web dashboard

### DIFF
--- a/zeroclaw/CHANGELOG.md
+++ b/zeroclaw/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.7.5.0
+
+- Update ZeroClaw binary to v0.7.5
+- Ship the prebuilt web dashboard: install path moved to `/opt/zeroclaw/` and `ZEROCLAW_WEB_DIST_DIR=/opt/zeroclaw/web/dist` exported at startup
+- Web onboarding flow at `/onboard` (schema-driven, full first-run UI in the browser)
+- Schema-driven config editor at `/config` with drift detection and per-row diff
+- Personality editor (CodeMirror) for the 7 runtime markdown files (`SOUL.md`, `IDENTITY.md`, `USER.md`, `AGENTS.md`, `TOOLS.md`, `HEARTBEAT.md`, `MEMORY.md`)
+- Live model switching, stop button, manual cron trigger in the dashboard
+- OpenAPI 3.1 spec at `/api/openapi.json`, Scalar explorer at `/api/docs`
+- ACP `session/cancel`, tool-approval back-channel, rejection of concurrent `session/prompt`
+- Per-provider pricing with cost/token usage recorded on every gateway turn
+
 ## 0.7.4.2
 
 - Write `env_vars` from HA config to `workspace/config/env_vars.conf` at startup so agent SOPs can read credentials via `file_read` (the shell tool cannot access env vars under `workspace_only` security policy)

--- a/zeroclaw/Dockerfile
+++ b/zeroclaw/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
 ARG BUILD_ARCH
-ARG ZEROCLAW_VERSION="0.7.4"
+ARG ZEROCLAW_VERSION="0.7.5"
 ARG AGENT_BROWSER_VERSION="0.25.3"
 ARG CLOUDFLARED_VERSION="2026.3.0"
 
@@ -22,16 +22,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install agent-browser (browser automation CLI — connects to browserless_chrome addon via CDP)
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} --omit=dev && npm cache clean --force
 
-# Download and extract ZeroClaw pre-built binary (glibc, compatible with Debian base)
+# Download and extract ZeroClaw pre-built binary + web/dist (glibc, compatible with Debian base)
+# The v0.7.5 tarball ships the daemon binary alongside a prebuilt web dashboard;
+# extract both into /opt/zeroclaw and symlink the binary into PATH.
 RUN case "${BUILD_ARCH}" in \
       aarch64) ARCH="aarch64-unknown-linux-gnu" ;; \
       amd64)   ARCH="x86_64-unknown-linux-gnu" ;; \
       *) echo "Unsupported arch: ${BUILD_ARCH}" && exit 1 ;; \
     esac && \
+    mkdir -p /opt/zeroclaw && \
     curl -fsSL \
       "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v${ZEROCLAW_VERSION}/zeroclaw-${ARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin && \
-    chmod +x /usr/local/bin/zeroclaw
+      | tar -xz -C /opt/zeroclaw && \
+    chmod +x /opt/zeroclaw/zeroclaw && \
+    ln -sf /opt/zeroclaw/zeroclaw /usr/local/bin/zeroclaw
 
 # Download cloudflared binary (required for Cloudflare Tunnel support)
 RUN case "${BUILD_ARCH}" in \
@@ -56,7 +60,7 @@ RUN case "${BUILD_ARCH}" in \
     chmod +x /usr/local/bin/ttyd
 
 # Cache-bust: increment when rootfs scripts change to force layer rebuild
-ARG ROOTFS_VERSION=24
+ARG ROOTFS_VERSION=25
 # Copy S6-overlay services and scripts
 COPY rootfs /
 

--- a/zeroclaw/build.yaml
+++ b/zeroclaw/build.yaml
@@ -2,6 +2,6 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
 args:
-  ZEROCLAW_VERSION: "0.7.4"
+  ZEROCLAW_VERSION: "0.7.5"
   AGENT_BROWSER_VERSION: "0.25.3"
   CLOUDFLARED_VERSION: "2026.3.0"

--- a/zeroclaw/config.yaml
+++ b/zeroclaw/config.yaml
@@ -1,5 +1,5 @@
 name: "ZeroClaw"
-version: "0.7.4.2"
+version: "0.7.5.0"
 slug: "zeroclaw"
 description: "Lightweight AI daemon with persistent memory, tools, cron scheduling, and messaging integrations"
 url: "https://www.zeroclawlabs.ai"

--- a/zeroclaw/rootfs/etc/s6-overlay/s6-rc.d/zeroclaw/run
+++ b/zeroclaw/rootfs/etc/s6-overlay/s6-rc.d/zeroclaw/run
@@ -169,6 +169,9 @@ else
     bashio::log.info "No browser addon detected — browser tools unavailable. Install browserless_chrome addon to enable."
 fi
 
+# ── Web dashboard path (shipped in the v0.7.5+ tarball) ──────────────────────
+export ZEROCLAW_WEB_DIST_DIR="/opt/zeroclaw/web/dist"
+
 # ── Start daemon ──────────────────────────────────────────────────────────────
 bashio::log.info "Starting ZeroClaw daemon..."
 exec /usr/local/bin/zeroclaw daemon


### PR DESCRIPTION
## Summary

- Bump ZeroClaw upstream binary 0.7.4 → 0.7.5
- Ship the prebuilt web dashboard: install path moved to `/opt/zeroclaw/` and `ZEROCLAW_WEB_DIST_DIR=/opt/zeroclaw/web/dist` exported at startup so the daemon serves the new schema-driven `/onboard`, `/config`, and personality editor instead of falling back to API-only mode
- Bump addon version 0.7.4.2 → 0.7.5.0 and `ROOTFS_VERSION` to force layer rebuild

Closes #10

## Test plan

- [ ] Build succeeds on both `aarch64` and `amd64` (HA Add-on Store → Rebuild)
- [ ] Open ingress: the v0.7.5 web dashboard renders (not the "Web dashboard not available" fallback)
- [ ] `/api/openapi.json` and `/api/docs` are reachable
- [ ] Existing `/share/zeroclaw/.zeroclaw/config.toml` continues to load without manual migration
- [ ] Home Assistant MCP injection still works (`[[mcp.servers]] name = "home-assistant"` block present after restart when `ha_mcp_enabled: true`)
- [ ] `env_vars` from HA config still land in `/share/zeroclaw/.zeroclaw/workspace/config/env_vars.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)