### PR TITLE
feat(zeroclaw): expose port 42618 for webhook channel

### DIFF
--- a/zeroclaw/CHANGELOG.md
+++ b/zeroclaw/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.5.1
+
+- Expose port `42618/tcp` for the `[channels.webhook]` channel (HTTP endpoint for SOP triggers). The channel is opt-in: enable and configure it in `config.toml` to start using SOP webhook triggers
+
 ## 0.7.5.0
 
 - Update ZeroClaw binary to v0.7.5

--- a/zeroclaw/DOCS.md
+++ b/zeroclaw/DOCS.md
@@ -65,6 +65,68 @@ You can edit workspace files using the Home Assistant **File Editor** add-on or 
 
 After the first start, you can edit `config.toml` directly for options not exposed in the add-on UI. Changes take effect after restarting the add-on.
 
+## Webhook channel (SOP triggers)
+
+ZeroClaw v0.7.5+ ships a dedicated **webhook channel** that exposes an HTTP endpoint for triggering Standard Operating Procedures (SOPs) on demand. This is the canonical way to fire a specific SOP from external systems (Home Assistant automations, Node-RED, cron, curl) without sending a free-form chat message to the main gateway.
+
+### Enable the channel
+
+The channel is opt-in. Add to `/share/zeroclaw/.zeroclaw/config.toml`:
+
+```toml
+[channels.webhook]
+enabled = true
+port = 42618
+listen_path = "/sops"
+# secret = "your-shared-secret"   # optional, HMAC-SHA256 signature verification
+```
+
+Port `42618` is exposed by this add-on. After saving, restart the add-on.
+
+### Define a SOP
+
+SOPs live in `/share/zeroclaw/.zeroclaw/workspace/sops/<name>/`. Each SOP is a directory with two files:
+
+```
+sops/
+  ping/
+    SOP.toml      # metadata + trigger definition
+    SOP.md        # instructions the agent follows when triggered
+```
+
+Declare a webhook trigger in `SOP.toml`:
+
+```toml
+name = "ping"
+description = "Health check SOP — replies with a pong and timestamp"
+
+[trigger]
+type = "webhook"
+```
+
+`SOP.md` contains the prompt the agent receives when the SOP fires:
+
+```markdown
+You were triggered by a webhook. Respond with: "pong" plus the current UTC timestamp.
+Do not call any tool. Keep the response under 50 characters.
+```
+
+### Trigger from outside
+
+```bash
+curl -X POST http://<ha-ip>:42618/sops \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+The channel routes the incoming POST to the matching SOP and the agent executes `SOP.md` against your configured model.
+
+### Security
+
+- The channel binds on `0.0.0.0:42618` inside the container, which Home Assistant exposes on the host LAN. Anyone on your network can hit it.
+- Set `secret` in `[channels.webhook]` to require an HMAC-SHA256 signature on incoming requests.
+- Do not expose port 42618 to the public internet without authentication.
+
 ## Browser automation
 
 Browser automation is **not available by default**. To enable it, install the **Browserless Chromium** add-on from the [alexbelgium repository](https://github.com/alexbelgium/hassio-addons).

--- a/zeroclaw/config.yaml
+++ b/zeroclaw/config.yaml
@@ -1,5 +1,5 @@
 name: "ZeroClaw"
-version: "0.7.5.0"
+version: "0.7.5.1"
 slug: "zeroclaw"
 description: "Lightweight AI daemon with persistent memory, tools, cron scheduling, and messaging integrations"
 url: "https://www.zeroclawlabs.ai"
@@ -30,8 +30,10 @@ map:
   - share:rw
 ports:
   "42617/tcp": 42617
+  "42618/tcp": 42618
 ports_description:
   "42617/tcp": "ZeroClaw Web Dashboard"
+  "42618/tcp": "ZeroClaw Webhook Channel"
 ingress: true
 ingress_port: 7681
 panel_icon: mdi:robot


### PR DESCRIPTION
## Summary

- Expose port `42618/tcp` on the addon to make ZeroClaw's `[channels.webhook]` channel reachable from the LAN
- Document `[channels.webhook]` setup and SOP webhook triggers in `DOCS.md`
- Bump addon version 0.7.5.0 → 0.7.5.1 (manifest-only — no Dockerfile/rootfs change, no rebuild required, just an update)

Closes #12

## Test plan

- [ ] Update the addon (no Rebuild needed — manifest-only change)
- [ ] Edit `/share/zeroclaw/.zeroclaw/config.toml`, add `[channels.webhook]` block with `port = 42618`, restart
- [ ] In addon logs see something like `Webhook channel listening on http://0.0.0.0:42618`
- [ ] Create a fake `ping` SOP in `<workspace>/sops/ping/` with `trigger.type = "webhook"`
- [ ] `curl -X POST http://<ha-ip>:42618/sops -d '{}'` — agent executes the SOP and replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)