### PR TITLE
feat(zeroclaw)!: bump to 0.8.0 (multi-agent, schema V3, zerocode TUI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Every add-on follows this layout:
 - **Base image**: `ghcr.io/home-assistant/{arch}-base-debian:bookworm` for both `aarch64` and `amd64`
 - **ttyd**: always version 1.7.7, downloaded from GitHub releases, port 7681 (ingress)
 - **Persistent data**: `/share/<addon>/` — survives restarts and updates
-- **Config location**: `/share/<addon>/.<addon>/` (e.g. `.zeroclaw/config.toml`, `.nullclaw/config.json`)
+- **Config location**: `/share/<addon>/.<addon>/` (e.g. `.zeroclaw/config.toml`, `.nullclaw/config.json`); ZeroClaw v0.8.0+ also uses `agents/<alias>/workspace/` per agent (default alias = `default`) and `shared/skills/` for host-wide skill bundles
 - **HA options**: `timezone` (str), `ha_mcp_enabled` (bool), `gateway_pairing` (bool) — PicoClaw has no `gateway_pairing`; ZeroClaw/PicoClaw/OpenClaw also have `browser_cdp_port` (int); NullClaw has no browser CDP option
 - **boot**: `auto` on all four
 - **panel_icon**: `mdi:robot` on all four
@@ -49,7 +49,7 @@ Every add-on follows this layout:
 | Install | Binary (Rust, GitHub releases) | Binary (Go, GitHub releases) | `npm install -g openclaw` | Binary (Zig, GitHub releases) |
 | Config format | TOML (`config.toml`) | JSON (`config.json`) | JSON (`openclaw.json`) | JSON (`config.json`) |
 | Gateway port | 42617 | 18800 | 38789 | 43000 |
-| First run | `zeroclaw onboard` | launcher web UI | `openclaw configure` | `nullclaw onboard --interactive` |
+| First run | `zeroclaw onboard` (then `zeroclaw agent -a default` for chat in V3) | launcher web UI | `openclaw configure` | `nullclaw onboard --interactive` |
 | `gateway_pairing` | `require_pairing` in TOML | — (always auth) | `dangerouslyDisableDeviceAuth` in JSON | `require_pairing` in JSON |
 | MCP key | `[[mcp.servers]]` TOML append | `tools.mcp.servers` jq merge | `mcpServers` jq merge | `mcp_servers` jq merge |
 | Browser CDP | `~/.agent-browser/config.json` | `~/.agent-browser/config.json` | `cdpUrl` in openclaw.json | None (uses xdg-open only; no CDP support) |

--- a/zeroclaw/CHANGELOG.md
+++ b/zeroclaw/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.8.0.0
+
+- **Major upstream release**: bump ZeroClaw binary to v0.8.0. See [upstream release notes](https://github.com/zeroclaw-labs/zeroclaw/releases/tag/v0.8.0) for the full list.
+- **Multi-agent runtime**: a single daemon now runs many named agents, each with its own workspace, memory, model provider, security policy, and channels. Existing single-agent configs are auto-migrated into a `default` agent.
+- **Config schema V3**: V2→V3 migration is committed to disk on first boot via `zeroclaw config migrate` (idempotent). The marker file flips from `.v2_migrated` to `.v3_migrated`. On-disk filesystem layout moves `workspace/` → `agents/default/workspace/` (handled by the daemon on first load).
+- **`zerocode` terminal UI**: new TUI binary bundled in the tarball and symlinked into `PATH`. Launch from the add-on web terminal with `zerocode`.
+- **Install root**: explicit `ZEROCLAW_CONFIG_DIR=/share/zeroclaw/.zeroclaw` is now exported at boot (priority 1 in V3 path resolution); the legacy `/usr/local/var/zeroclaw` symlink is dropped.
+- **`env_vars.conf` path**: moves from `workspace/config/env_vars.conf` to `agents/default/workspace/config/env_vars.conf` to match the per-agent V3 workspace layout. Update any skill that hardcoded the legacy path.
+- **Lean default channel bundle**: the prebuilt linux-gnu binary ships ACP, webhook, email, and Telegram out of the box; other channels (Discord, Slack, Matrix, IRC, WhatsApp, etc.) are now opt-in build features and **not available** in this add-on's binary.
+- **Webhook channel**: rewritten in V3 as `[channels.webhook.<alias>]` (map of named webhooks). The 0.7.x `[channels.webhook]` form is auto-migrated by the daemon; the exposed port `42618/tcp` is unchanged.
+- **Tunnel**: `[tunnel] provider = "..."` is renamed to `[tunnel] tunnel_provider = "..."` in V3 (auto-migrated). `cloudflared` ships unchanged for users who run a Cloudflare Tunnel.
+- **Gateway / MCP TOML shape**: `[gateway]` and top-level `[[mcp.servers]]` are byte-compatible with V3; the add-on's on-boot sed/awk autopatch keeps working unchanged.
+- **Security hardening**: per-agent tool allowlists enforced at every dispatch, bearer-token revocation on device rotation/deletion, private-host allowlists for outbound HTTP, Canvas iframe sandbox tightened (GHSA-f385-f6h2-3gqj).
+
 ## 0.7.5.4
 
 - Fix env_vars injection and `env_vars.conf` accumulating duplicates (observed 32× duplication at runtime). Replace `bashio::config` index iteration with a `jq`-based read of `/data/options.json` using `unique_by(.name)`. Atomic write via tmp file. `env_vars.conf` is chmod `600` since it can contain credentials

--- a/zeroclaw/DOCS.md
+++ b/zeroclaw/DOCS.md
@@ -1,6 +1,6 @@
 # ZeroClaw Add-on for Home Assistant
 
-ZeroClaw is a lightweight AI daemon with persistent memory, workspace files, cron scheduling, and tool integrations (web search, file operations, HTTP requests, browser automation, and more).
+ZeroClaw is a multi-agent AI daemon with persistent memory, workspace files, cron scheduling, and tool integrations (web search, file operations, HTTP requests, browser automation, and more). A single daemon can run many named agents, each with its own workspace, memory, model provider, security policy, and channels.
 
 This add-on installs ZeroClaw using pre-built binaries — no Rust compilation required. Startup time is under 30 seconds even on Raspberry Pi.
 
@@ -59,11 +59,36 @@ The add-on includes a browser-based terminal (ttyd) accessible from the **ZeroCl
 All ZeroClaw data is stored in `/share/zeroclaw/`:
 
 - `.zeroclaw/config.toml` — generated on first start, then managed via the web dashboard
-- `.zeroclaw/workspace/` — workspace files (SOUL.md, IDENTITY.md, MEMORY.md, TOOLS.md, etc.)
+- `.zeroclaw/agents/default/workspace/` — per-agent workspace (SOUL.md, IDENTITY.md, MEMORY.md, TOOLS.md, …)
+- `.zeroclaw/shared/skills/` — host-wide skill bundles shared across every agent
+- `.zeroclaw/data/` — shared databases (memory, sessions, cost records, secrets)
 
 You can edit workspace files using the Home Assistant **File Editor** add-on or via SSH.
 
 After the first start, you can edit `config.toml` directly for options not exposed in the add-on UI. Changes take effect after restarting the add-on.
+
+## Upgrading from 0.7.x
+
+The first boot on 0.8.0 runs the V2 → V3 migration automatically:
+
+1. `zeroclaw config migrate` rewrites `config.toml` to schema V3 (a `.backup` file is dropped next to the original).
+2. On the next daemon load, `/share/zeroclaw/.zeroclaw/workspace/` is moved into `/share/zeroclaw/.zeroclaw/agents/default/workspace/` and a full pre-split copy is kept under `backup-<timestamp>/`.
+3. The `[channels.webhook]` and `[tunnel] provider` keys are rewritten to V3 form (`[channels.webhook.default]`, `[tunnel] tunnel_provider`) in place.
+
+Take a Home Assistant snapshot before the upgrade. If you have custom skills referencing absolute workspace paths, update them to the new `agents/default/workspace/` location.
+
+## Multi-agent
+
+V3 supports running many agents from one daemon. The 0.7.x single-agent setup is migrated into an agent named `default`. To add another agent, edit `config.toml` and append a block like:
+
+```toml
+[agents.research]
+model_provider = "groq"
+risk_profile = "supervised"
+channels = ["telegram"]
+```
+
+Each agent gets its own `agents/<alias>/workspace/` directory created on first boot. Use `zeroclaw agent -a <alias>` to start an interactive chat with a specific agent.
 
 ## Webhook channel (SOP triggers)
 
@@ -71,21 +96,28 @@ ZeroClaw v0.7.5+ ships a dedicated **webhook channel** that exposes an HTTP endp
 
 ### Enable the channel
 
-The channel is opt-in. Add to `/share/zeroclaw/.zeroclaw/config.toml`:
+The channel is opt-in. In V3 it lives under a named map. Add to `/share/zeroclaw/.zeroclaw/config.toml`:
 
 ```toml
-[channels.webhook]
+[channels.webhook.default]
 enabled = true
 port = 42618
 listen_path = "/sops"
 # secret = "your-shared-secret"   # optional, HMAC-SHA256 signature verification
 ```
 
+Then opt your agent into the channel:
+
+```toml
+[agents.default]
+channels = ["webhook.default"]
+```
+
 Port `42618` is exposed by this add-on. After saving, restart the add-on.
 
 ### Define a SOP
 
-SOPs live in `/share/zeroclaw/.zeroclaw/workspace/sops/<name>/`. Each SOP is a directory with two files:
+SOPs live in `/share/zeroclaw/.zeroclaw/agents/default/workspace/sops/<name>/`. Each SOP is a directory with two files:
 
 ```
 sops/
@@ -124,7 +156,7 @@ The channel routes the incoming POST to the matching SOP and the agent executes 
 ### Security
 
 - The channel binds on `0.0.0.0:42618` inside the container, which Home Assistant exposes on the host LAN. Anyone on your network can hit it.
-- Set `secret` in `[channels.webhook]` to require an HMAC-SHA256 signature on incoming requests.
+- Set `secret` in `[channels.webhook.default]` to require an HMAC-SHA256 signature on incoming requests.
 - Do not expose port 42618 to the public internet without authentication.
 
 ## Browser automation

--- a/zeroclaw/Dockerfile
+++ b/zeroclaw/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
 ARG BUILD_ARCH
-ARG ZEROCLAW_VERSION="0.7.5"
+ARG ZEROCLAW_VERSION="0.8.0"
 ARG AGENT_BROWSER_VERSION="0.25.3"
 ARG CLOUDFLARED_VERSION="2026.3.0"
 
@@ -23,8 +23,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} --omit=dev && npm cache clean --force
 
 # Download and extract ZeroClaw pre-built binary + web/dist (glibc, compatible with Debian base)
-# The v0.7.5 tarball ships the daemon binary alongside a prebuilt web dashboard;
-# extract both into /opt/zeroclaw and symlink the binary into PATH.
+# The v0.8.0 tarball ships the daemon binary, the new `zerocode` terminal UI,
+# and a prebuilt web dashboard; extract everything into /opt/zeroclaw and
+# symlink both binaries into PATH.
 RUN case "${BUILD_ARCH}" in \
       aarch64) ARCH="aarch64-unknown-linux-gnu" ;; \
       amd64)   ARCH="x86_64-unknown-linux-gnu" ;; \
@@ -34,8 +35,9 @@ RUN case "${BUILD_ARCH}" in \
     curl -fsSL \
       "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v${ZEROCLAW_VERSION}/zeroclaw-${ARCH}.tar.gz" \
       | tar -xz -C /opt/zeroclaw && \
-    chmod +x /opt/zeroclaw/zeroclaw && \
-    ln -sf /opt/zeroclaw/zeroclaw /usr/local/bin/zeroclaw
+    chmod +x /opt/zeroclaw/zeroclaw /opt/zeroclaw/zerocode && \
+    ln -sf /opt/zeroclaw/zeroclaw /usr/local/bin/zeroclaw && \
+    ln -sf /opt/zeroclaw/zerocode /usr/local/bin/zerocode
 
 # Download cloudflared binary (required for Cloudflare Tunnel support)
 RUN case "${BUILD_ARCH}" in \
@@ -60,7 +62,7 @@ RUN case "${BUILD_ARCH}" in \
     chmod +x /usr/local/bin/ttyd
 
 # Cache-bust: increment when rootfs scripts change to force layer rebuild
-ARG ROOTFS_VERSION=28
+ARG ROOTFS_VERSION=29
 # Copy S6-overlay services and scripts
 COPY rootfs /
 

--- a/zeroclaw/build.yaml
+++ b/zeroclaw/build.yaml
@@ -2,6 +2,6 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
 args:
-  ZEROCLAW_VERSION: "0.7.5"
+  ZEROCLAW_VERSION: "0.8.0"
   AGENT_BROWSER_VERSION: "0.25.3"
   CLOUDFLARED_VERSION: "2026.3.0"

--- a/zeroclaw/config.yaml
+++ b/zeroclaw/config.yaml
@@ -1,5 +1,5 @@
 name: "ZeroClaw"
-version: "0.7.5.4"
+version: "0.8.0.0"
 slug: "zeroclaw"
 description: "Lightweight AI daemon with persistent memory, tools, cron scheduling, and messaging integrations"
 url: "https://www.zeroclawlabs.ai"

--- a/zeroclaw/rootfs/etc/profile.d/zeroclaw.sh
+++ b/zeroclaw/rootfs/etc/profile.d/zeroclaw.sh
@@ -13,14 +13,16 @@ cat <<'EOF'
 
 ZeroClaw container shell. Available commands:
 
-  zeroclaw agent          Start interactive chat session
-  zeroclaw status         Show current configuration
-  zeroclaw onboard        Re-run initial setup wizard
-  zeroclaw cron list      List scheduled tasks
-  zeroclaw channel list   List configured channels
-  zeroclaw doctor         Run diagnostics
+  zeroclaw agent -a default   Start interactive chat session (multi-agent: pick alias)
+  zeroclaw status             Show current configuration
+  zeroclaw onboard            Re-run initial setup wizard
+  zeroclaw cron list          List scheduled tasks
+  zeroclaw channel list       List configured channels
+  zeroclaw doctor             Run diagnostics
+  zerocode                    Open the new terminal UI (Chat, Code, Dashboard, Logs)
 
-  Config:  /share/zeroclaw/.zeroclaw/config.toml
-  Workspace: /share/zeroclaw/workspace/
+  Config:    /share/zeroclaw/.zeroclaw/config.toml
+  Workspace: /share/zeroclaw/.zeroclaw/agents/default/workspace/
+  Shared:    /share/zeroclaw/.zeroclaw/shared/skills/
 
 EOF

--- a/zeroclaw/rootfs/etc/s6-overlay/s6-rc.d/zeroclaw/run
+++ b/zeroclaw/rootfs/etc/s6-overlay/s6-rc.d/zeroclaw/run
@@ -8,12 +8,15 @@ export SHELL="/bin/bash"
 
 ZEROCLAW_DATA="/share/zeroclaw/.zeroclaw"
 CONFIG_FILE="${ZEROCLAW_DATA}/config.toml"
-mkdir -p "${ZEROCLAW_DATA}" "${HOME}/workspace"
-
-# Redirect ZeroClaw's default internal data dir to the persistent share volume.
-# v0.6.8+ uses /usr/local/var/zeroclaw/ instead of ~/.zeroclaw/ — symlink it.
-mkdir -p /usr/local/var
-ln -sfn "${ZEROCLAW_DATA}" /usr/local/var/zeroclaw
+# v0.8.0+ resolves the install root from ZEROCLAW_CONFIG_DIR (priority 1) —
+# explicit beats relying on HOME/legacy fallbacks. Pre-create the V3 layout:
+# data/ (shared DBs), shared/skills/ (host-wide skills), and the per-agent
+# workspace for the implicit "default" agent created by V2→V3 migration.
+export ZEROCLAW_CONFIG_DIR="${ZEROCLAW_DATA}"
+mkdir -p \
+    "${ZEROCLAW_DATA}/data" \
+    "${ZEROCLAW_DATA}/shared/skills" \
+    "${ZEROCLAW_DATA}/agents/default/workspace"
 
 # ── Inject environment variables from HA UI configuration ────────────────────
 # Source via jq from /data/options.json (single source of truth, deduped).
@@ -30,7 +33,9 @@ fi
 # (shell tool cannot access env vars under workspace_only security policy)
 # Build via jq from /data/options.json — single source of truth, no bashio loop
 # (bashio::config iteration was observed duplicating entries 32x at runtime).
-WORKSPACE_CONFIG="${ZEROCLAW_DATA}/workspace/config"
+# V3 splits the workspace per agent: write under the default agent's workspace,
+# which is where the V2→V3 filesystem migration moves the legacy workspace/.
+WORKSPACE_CONFIG="${ZEROCLAW_DATA}/agents/default/workspace/config"
 mkdir -p "${WORKSPACE_CONFIG}"
 ENV_VARS_FILE="${WORKSPACE_CONFIG}/env_vars.conf"
 if [ -f /data/options.json ]; then
@@ -48,13 +53,17 @@ if [ ! -f "${CONFIG_FILE}" ]; then
     exit 1
 fi
 
-# ── One-time config V2 migration (0.7.0+) ─────────────────────────────────────
-MIGRATED_MARKER="${ZEROCLAW_DATA}/.v2_migrated"
+# ── One-time config V3 migration (0.8.0+) ─────────────────────────────────────
+# V3 daemons auto-migrate in memory on every boot but leave config.toml on disk
+# stale until `zeroclaw config migrate` commits the change. Run it once per
+# install so the on-disk file is locked at schema_version = 3 and downstream
+# tooling that reads the TOML sees the canonical V3 shape. Idempotent.
+MIGRATED_MARKER="${ZEROCLAW_DATA}/.v3_migrated"
 if [ ! -f "${MIGRATED_MARKER}" ]; then
-    bashio::log.info "Running one-time config migration to V2..."
+    bashio::log.info "Running one-time config migration to V3..."
     if /usr/local/bin/zeroclaw config migrate 2>&1; then
         touch "${MIGRATED_MARKER}"
-        bashio::log.info "Config migration to V2 completed."
+        bashio::log.info "Config migration to V3 completed."
     else
         bashio::log.warning "Config migration failed — continuing with existing config."
         touch "${MIGRATED_MARKER}"


### PR DESCRIPTION
## Summary

- Bump ZeroClaw upstream binary from **0.7.5 → 0.8.0** (multi-agent runtime, schema V3, zerocode TUI, security hardening, lean default channel bundle).
- Add-on version `0.7.5.4` → `0.8.0.0`. `ROOTFS_VERSION` `28` → `29`.
- Rename one-time migration marker `.v2_migrated` → `.v3_migrated` so existing 0.7.x installs auto-commit the V3 schema with `zeroclaw config migrate` on first 0.8.0 boot.
- Export `ZEROCLAW_CONFIG_DIR=/share/zeroclaw/.zeroclaw` (priority-1 V3 install root resolver); drop the legacy `/usr/local/var/zeroclaw` symlink; pre-create the V3 layout (`data/`, `shared/skills/`, `agents/default/workspace/`).
- Move `env_vars.conf` from `workspace/config/` to `agents/default/workspace/config/` so it lives inside the V3 per-agent workspace after the daemon's V2→V3 filesystem migration.
- Symlink the new `zerocode` binary from the tarball into `PATH`.
- DOCS.md: rewrite webhook channel section for V3 (`[channels.webhook.<alias>]` + agent opt-in), update workspace paths, add a Multi-agent how-to + Upgrading-from-0.7.x section.
- CLAUDE.md (root): update workspace path and `First run` row.

The `[gateway]`, `[mcp]`, and top-level `[[mcp.servers]]` autopatch (sed/awk) blocks in `rootfs/.../zeroclaw/run` are byte-compatible with V3 and stay unchanged.

## Verification

- Schema diff: `crates/zeroclaw-config/src/migration.rs::CURRENT_SCHEMA_VERSION = 3`; gateway/MCP keys unchanged in `crates/zeroclaw-config/src/schema.rs`.
- Daemon load path (`Config::load_or_init`) auto-migrates V<3 in memory and triggers the `workspace/` → `agents/default/workspace/` filesystem move on first boot.
- Tarball layout verified: `zeroclaw`, `zerocode`, `web/dist/` at the same relative paths used by the Dockerfile.
- Web UI: gateway in v0.8.0 routes `/_app/*` through `static_files.rs::handle_static` against `${web_dist_dir}` (= `/opt/zeroclaw/web/dist`). Every `/_app/...` reference in the shipped `index.html` resolves to an asset present in the tarball; only the favicon `zeroclaw-trans.png` is missing upstream (cosmetic).

## Test plan

- [ ] Take a Home Assistant snapshot of `antonello` (ha.sallemi.it).
- [ ] Trigger Settings → Add-ons → ZeroClaw → Check for updates → Update (rebuild).
- [ ] On first boot, confirm in logs:
  - [ ] `Running one-time config migration to V3...`
  - [ ] `Gateway configured (port=42617, pairing=true, web_dist_dir=/opt/zeroclaw/web/dist)`
  - [ ] `Browser addon detected — configuring agent-browser CDP at ws://172.30.32.1:3000`
  - [ ] No FATAL on missing config (the existing config.toml is preserved).
- [ ] Verify on disk:
  - [ ] `/share/zeroclaw/.zeroclaw/.v3_migrated` exists.
  - [ ] `/share/zeroclaw/.zeroclaw/agents/default/workspace/` contains the migrated identity files (SOUL.md, IDENTITY.md, MEMORY.md, …).
  - [ ] `/share/zeroclaw/.zeroclaw/data/` holds the SQLite databases.
  - [ ] A `backup-<timestamp>/` directory was dropped under `/share/zeroclaw/.zeroclaw/`.
- [ ] Open `http://ha.sallemi.it:42617/` and confirm the multi-agent dashboard loads (Dashboard, Agents, Memories, Cost panes visible).
- [ ] Open the ZeroClaw web terminal (ingress) and run `zerocode` — confirm the TUI launches and connects to the local daemon.
- [ ] Telegram channel still delivers messages to the `default` agent.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)