### PR TITLE
fix(zeroclaw): inject HA MCP in V3 dotted form to avoid duplicate-key crash

### DIFF
--- a/zeroclaw/CHANGELOG.md
+++ b/zeroclaw/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.0.1
+
+- Fix daemon crash-loop (`Config contains malformed security-critical sections (<entire-config>)`) after the 0.7.5.4 → 0.8.0.0 upgrade. Upstream's V2→V3 migrator emits a `[mcp.servers.headers]` orphan dotted sub-table from any V2 `[[mcp.servers]]` whose `headers` field is an inline-table, dropping `name`/`transport`/`url`. The run script then appended `[[mcp.servers]]` for HA MCP, declaring `mcp.servers` as both a table and an array → duplicate-key TOML parse error.
+- Run script now strips three shapes before re-injecting HA MCP: V2 `[[mcp.servers]]` with `name = "home-assistant"`, V3 dotted `[mcp.servers.home-assistant]` plus its sub-tables, and the migrator orphan `[mcp.servers.headers]`. User-defined MCP entries (other names, other forms) are preserved.
+- HA MCP is now injected in V3-native dotted form (`[mcp.servers.home-assistant]` + `[mcp.servers.home-assistant.headers]`) to coexist cleanly with anything else the daemon writes under `mcp.servers.*`.
+
 ## 0.8.0.0
 
 - **Major upstream release**: bump ZeroClaw binary to v0.8.0. See [upstream release notes](https://github.com/zeroclaw-labs/zeroclaw/releases/tag/v0.8.0) for the full list.

--- a/zeroclaw/Dockerfile
+++ b/zeroclaw/Dockerfile
@@ -62,7 +62,7 @@ RUN case "${BUILD_ARCH}" in \
     chmod +x /usr/local/bin/ttyd
 
 # Cache-bust: increment when rootfs scripts change to force layer rebuild
-ARG ROOTFS_VERSION=29
+ARG ROOTFS_VERSION=30
 # Copy S6-overlay services and scripts
 COPY rootfs /
 

--- a/zeroclaw/config.yaml
+++ b/zeroclaw/config.yaml
@@ -1,5 +1,5 @@
 name: "ZeroClaw"
-version: "0.8.0.0"
+version: "0.8.0.1"
 slug: "zeroclaw"
 description: "Lightweight AI daemon with persistent memory, tools, cron scheduling, and messaging integrations"
 url: "https://www.zeroclawlabs.ai"

--- a/zeroclaw/rootfs/etc/s6-overlay/s6-rc.d/zeroclaw/run
+++ b/zeroclaw/rootfs/etc/s6-overlay/s6-rc.d/zeroclaw/run
@@ -82,27 +82,36 @@ else
     bashio::log.warning "Unknown timezone '${TIMEZONE}', falling back to UTC."
 fi
 
-# ── V2 compat: remove inline "servers = [...]" from [mcp] section ────────────
-# ZeroClaw 0.7.x may rewrite [[mcp.servers]] as inline arrays; we always use the
-# array-of-tables form so we strip any inline definition to avoid duplicate keys.
-sed -i '/^\[mcp\]/,/^\[/{/^servers = \[/d}' "${CONFIG_FILE}"
-
-# ── Remove only the managed home-assistant MCP block before re-injection ───────
-# Uses awk to surgically remove the [[mcp.servers]] block with name = "home-assistant"
-# while leaving all user-defined [[mcp.servers]] entries untouched.
+# ── Strip every managed/broken home-assistant MCP block before re-injection ───
+# We must handle three shapes that may all coexist on upgraded installs:
+#   1. V2 array-of-tables:  [[mcp.servers]] with name = "home-assistant"
+#   2. V3 dotted form:      [mcp.servers.home-assistant] (+ sub-tables)
+#   3. V3 migrator orphan:  [mcp.servers.headers] left over when the buggy
+#      V2→V3 migration drops name/transport/url and only emits the headers
+#      sub-table (see issue #16).
+# A single awk pass buffers each section header + its body and only emits it
+# if it does NOT match one of the three drop patterns. User-defined MCP
+# servers under [mcp.servers.<other>] or [[mcp.servers]] with a different
+# name are preserved.
 MCP_HA="${ZEROCLAW_DATA}/mcp-ha.toml"
 awk '
-BEGIN { in_block=0; ha_block=0; block_buf="" }
+function flush_block() {
+    if (block_buf != "" && !drop_block) printf "%s", block_buf
+    block_buf = ""; drop_block = 0
+}
+BEGIN { block_buf = ""; drop_block = 0; in_aot = 0 }
 /^\[/ {
-    if (block_buf != "" && !ha_block) printf "%s", block_buf
-    block_buf = ""; ha_block = 0
-    if (/^\[\[mcp\.servers\]\]/) { in_block=1; block_buf=$0 "\n" }
-    else { in_block=0; print }
+    flush_block()
+    block_buf = $0 "\n"
+    in_aot = 0
+    if ($0 == "[mcp.servers.headers]") { drop_block = 1; next }
+    if ($0 ~ /^\[mcp\.servers\.home-assistant(\..*)?\]$/) { drop_block = 1; next }
+    if ($0 == "[[mcp.servers]]") { in_aot = 1; next }
     next
 }
-in_block { block_buf=block_buf $0 "\n"; if (/^name = "home-assistant"/) ha_block=1; next }
-{ print }
-END { if (block_buf != "" && !ha_block) printf "%s", block_buf }
+in_aot && /^name = "home-assistant"$/ { drop_block = 1 }
+{ block_buf = block_buf $0 "\n" }
+END { flush_block() }
 ' "${CONFIG_FILE}" > "${CONFIG_FILE}.tmp" && mv "${CONFIG_FILE}.tmp" "${CONFIG_FILE}"
 
 # ── Home Assistant MCP integration ────────────────────────────────────────────
@@ -111,7 +120,6 @@ if bashio::var.true "${HA_MCP_ENABLED}"; then
     if grep -q '^\[mcp\]' "${CONFIG_FILE}" 2>/dev/null; then
         sed -i '/^\[mcp\]/,/^\[/{s/^enabled = false$/enabled = true/}' "${CONFIG_FILE}"
         sed -i '/^\[mcp\]/,/^\[/{s/^deferred_loading = true$/deferred_loading = false/}' "${CONFIG_FILE}"
-        sed -i '/^servers = \[\]$/d' "${CONFIG_FILE}"
         bashio::log.info "MCP section updated: enabled = true, deferred_loading = false."
     else
         cat >> "${CONFIG_FILE}" <<EOF
@@ -122,17 +130,21 @@ deferred_loading = false
 EOF
     fi
 
+    # Inject HA MCP server in V3-native dotted form. [[mcp.servers]] (array of
+    # tables) would conflict with any dotted sub-table the migrator may have
+    # left under mcp.servers.* and produces a duplicate-key TOML parse error.
     HA_TOKEN="${SUPERVISOR_TOKEN}"
     cat > "${MCP_HA}" <<EOF
 
-[[mcp.servers]]
-name = "home-assistant"
+[mcp.servers.home-assistant]
 transport = "http"
 url = "http://supervisor/core/api/mcp"
-headers = { Authorization = "Bearer ${HA_TOKEN}" }
+
+[mcp.servers.home-assistant.headers]
+Authorization = "Bearer ${HA_TOKEN}"
 EOF
     cat "${MCP_HA}" >> "${CONFIG_FILE}"
-    bashio::log.info "Home Assistant MCP server configured."
+    bashio::log.info "Home Assistant MCP server configured (V3 dotted form)."
 else
     rm -f "${MCP_HA}"
 fi


### PR DESCRIPTION
## Summary

Hotfix for the crash-loop introduced by #15 (0.8.0.0 bump). Daemon refused to start with `Config contains malformed security-critical sections (<entire-config>)` because the post-upgrade `config.toml` carried a duplicate-key TOML parse error:

```
TOML parse error at line N, column 7
   | [[mcp.servers]]
   |       ^^^^^^^
   duplicate key
```

Two compounding issues:

1. **Upstream migrator bug**: a V2 `[[mcp.servers]]` whose `headers` field is an inline-table gets emitted as a dotted sub-table `[mcp.servers.headers]` with only `Authorization`, dropping `name`/`transport`/`url`. That orphan declares `mcp.servers` as a TOML **table**.
2. **Our run script** then appended `[[mcp.servers]]` for HA MCP on every boot, declaring `mcp.servers` as an **array of tables**. TOML can't have both.

## Changes

- `rootfs/etc/s6-overlay/s6-rc.d/zeroclaw/run`:
  - Strip awk now handles three shapes before re-injection: V2 AOT (`[[mcp.servers]]` with `name = "home-assistant"`), V3 dotted (`[mcp.servers.home-assistant]` + sub-tables), and the migrator orphan (`[mcp.servers.headers]`). User-defined MCP servers under any other name are preserved.
  - Inject HA MCP in V3-native dotted form (`[mcp.servers.home-assistant]` + `[mcp.servers.home-assistant.headers]`).
  - Drop the obsolete V2 sed for inline `servers = [...]` (V3 doesn't have it).
- `zeroclaw/config.yaml`: 0.8.0.0 → 0.8.0.1
- `zeroclaw/Dockerfile`: `ROOTFS_VERSION` 29 → 30
- `zeroclaw/CHANGELOG.md`: entry for 0.8.0.1

## Verification

Awk tested offline against synthetic input containing all three broken shapes plus user-defined entries — only the broken ones are dropped, user entries are preserved. See PR commits for the test.

ha.sallemi.it is currently up on 0.8.0.0 with `ha_mcp_enabled = false` (manual mitigation). After this PR merges + rebuild + re-enabling `ha_mcp_enabled`, the run script will produce a V3-valid config and HA MCP will reconnect.

## Test plan

- [ ] HA: Settings → Add-ons → ZeroClaw → Update to 0.8.0.1 (rebuild).
- [ ] Verify daemon starts (no `malformed security-critical sections` in logs).
- [ ] Verify `grep -n '^\[mcp.servers' /share/zeroclaw/.zeroclaw/config.toml` shows only the V3 dotted form when `ha_mcp_enabled = false`.
- [ ] Set `ha_mcp_enabled = true` from add-on options → restart → check log line `Home Assistant MCP server configured (V3 dotted form)`.
- [ ] Verify ZeroClaw agent can read/control HA entities through MCP (try `turn on light.X` from Telegram).

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)